### PR TITLE
Set up E2E tests with Playwright

### DIFF
--- a/packages/web/e2e/filters.spec.ts
+++ b/packages/web/e2e/filters.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Filter interactions', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('sport type filter is visible', async ({ page }) => {
+    await expect(page.getByText(/sport type/i)).toBeVisible();
+  });
+
+  test('date range filter is visible', async ({ page }) => {
+    await expect(page.getByText(/date range/i)).toBeVisible();
+  });
+
+  test('can toggle sport type checkboxes', async ({ page }) => {
+    // Find the Run checkbox
+    const runCheckbox = page.getByLabel(/run/i);
+    await expect(runCheckbox).toBeVisible();
+
+    // Should be checked by default (all selected)
+    await expect(runCheckbox).toBeChecked();
+
+    // Click to uncheck
+    await runCheckbox.click();
+    await expect(runCheckbox).not.toBeChecked();
+
+    // Click to check again
+    await runCheckbox.click();
+    await expect(runCheckbox).toBeChecked();
+  });
+
+  test('Select All button selects all sport types', async ({ page }) => {
+    // First uncheck one
+    const runCheckbox = page.getByLabel(/run/i);
+    await runCheckbox.click();
+    await expect(runCheckbox).not.toBeChecked();
+
+    // Click Select All
+    await page.getByRole('button', { name: /select all/i }).click();
+
+    // Run should now be checked
+    await expect(runCheckbox).toBeChecked();
+  });
+
+  test('Clear All button clears all sport types', async ({ page }) => {
+    // Click Clear All
+    await page.getByRole('button', { name: /clear all/i }).click();
+
+    // All checkboxes should be unchecked
+    const runCheckbox = page.getByLabel(/run/i);
+    await expect(runCheckbox).not.toBeChecked();
+  });
+
+  test('date inputs accept values', async ({ page }) => {
+    const fromInput = page.getByLabel(/from/i);
+    const toInput = page.getByLabel(/to/i);
+
+    await expect(fromInput).toBeVisible();
+    await expect(toInput).toBeVisible();
+
+    // Fill in dates
+    await fromInput.fill('2024-01-01');
+    await toInput.fill('2024-12-31');
+
+    await expect(fromInput).toHaveValue('2024-01-01');
+    await expect(toInput).toHaveValue('2024-12-31');
+  });
+});

--- a/packages/web/e2e/smoke.spec.ts
+++ b/packages/web/e2e/smoke.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Smoke tests', () => {
+  test('homepage loads successfully', async ({ page }) => {
+    await page.goto('/');
+
+    // App title should be visible
+    await expect(page.getByRole('heading', { name: /drift/i })).toBeVisible();
+  });
+
+  test('has header with navigation', async ({ page }) => {
+    await page.goto('/');
+
+    // Header should be present
+    const header = page.getByRole('banner');
+    await expect(header).toBeVisible();
+  });
+
+  test('has sidebar', async ({ page }) => {
+    await page.goto('/');
+
+    // Sidebar should be present
+    const sidebar = page.getByRole('complementary');
+    await expect(sidebar).toBeVisible();
+  });
+
+  test('has main content area', async ({ page }) => {
+    await page.goto('/');
+
+    // Main area should be present
+    const main = page.getByRole('main');
+    await expect(main).toBeVisible();
+  });
+});

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -10,7 +10,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:e2e": "echo 'Playwright not configured yet - see Issue #38'",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "lint": "eslint src --ext .ts,.tsx",
     "typecheck": "tsc --noEmit"
   },
@@ -21,6 +22,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@playwright/test": "^1.58.1",
     "@tailwindcss/postcss": "^4.1.18",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/packages/web/tsconfig.lint.json
+++ b/packages/web/tsconfig.lint.json
@@ -4,6 +4,6 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "typeRoots": ["./node_modules/@types", "../../node_modules/@types"]
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "e2e/**/*", "playwright.config.ts"],
   "exclude": ["node_modules", "dist", "coverage"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.10)(immer@11.1.3)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.1
+        version: 1.58.1
       '@tailwindcss/postcss':
         specifier: ^4.1.18
         version: 4.1.18
@@ -655,6 +658,11 @@ packages:
 
   '@petamoriken/float16@3.9.3':
     resolution: {integrity: sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==}
+
+  '@playwright/test@1.58.1':
+    resolution: {integrity: sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@probe.gl/env@4.1.0':
     resolution: {integrity: sha512-5ac2Jm2K72VCs4eSMsM7ykVRrV47w32xOGMvcgqn8vQdEMF9PRXyBGYEV9YbqRKWNKpNKmQJVi4AHM/fkCxs9w==}
@@ -1583,6 +1591,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2132,6 +2145,16 @@ packages:
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
+    hasBin: true
+
+  playwright-core@1.58.1:
+    resolution: {integrity: sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.1:
+    resolution: {integrity: sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==}
+    engines: {node: '>=18'}
     hasBin: true
 
   postcss-value-parser@4.2.0:
@@ -3176,6 +3199,10 @@ snapshots:
   '@petamoriken/float16@3.9.3':
     optional: true
 
+  '@playwright/test@1.58.1':
+    dependencies:
+      playwright: 1.58.1
+
   '@probe.gl/env@4.1.0': {}
 
   '@probe.gl/log@4.1.0':
@@ -4102,6 +4129,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4645,6 +4675,14 @@ snapshots:
   picomatch@4.0.3: {}
 
   pidtree@0.6.0: {}
+
+  playwright-core@1.58.1: {}
+
+  playwright@1.58.1:
+    dependencies:
+      playwright-core: 1.58.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-value-parser@4.2.0: {}
 


### PR DESCRIPTION
## Summary
- Install @playwright/test dependency
- Create playwright.config.ts with Chrome browser configuration
- Add smoke tests for basic page loading
- Add filter interaction tests for sport types and date range
- Configure test:e2e and test:e2e:ui npm scripts
- Update tsconfig.lint.json to include e2e directory

Closes #38

## Test plan
- [x] Smoke tests: homepage loads, header/sidebar/main visible
- [x] Filter tests: toggle checkboxes, Select All, Clear All, date inputs
- [x] All 433 unit tests pass (228 CLI + 205 web)

Note: E2E tests require `npx playwright install` for browsers and run with `pnpm test:e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)